### PR TITLE
Fix typo in docker image name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ For convenience I also include the [Universal Office Converter (unoconv)](https:
 
 ### Run
 
-`docker run -d --name libreoffice -p 8100:8100 hdejager/libreoffice-headless`
+`docker run -d --name libreoffice -p 8100:8100 hdejager/libreoffice-api`
 
 ### Try out unoconv (convert a HTML file to PDF):
 


### PR DESCRIPTION
Real name of image is `libreoffice-api`